### PR TITLE
Adding MSS530H

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -53,6 +53,10 @@
             "enum": ["MSS510M"]
           },
           {
+            "title": "MSS-530H",
+            "enum": ["MSS530H"]
+          },
+          {
             "title": "MSS-550",
             "enum": ["MSS550"]
           },


### PR DESCRIPTION
MSS530H is using same JSONS as MSS550. You only have to set an ChannelID 1, 2 or 3.
Channel 1 is the Top Outlet, Channel 2 the bottom left, Channel 3 the bottom right.