### PR TITLE
Add preliminary support for MSG200

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1272,10 +1272,8 @@ class Meross {
     if (response) {
       // Open means magnetic sensor not detected, doesn't really mean the door is open
       let isOpen = (this.currentState === Characteristic.CurrentDoorState.OPEN);
-      for(var i = 0; i < response.payload.all.digest.garageDoor.length; i++)
-      {
-        if(response.payload.all.digest.garageDoor[i].channel == this.config.channel)
-        {
+      for(let i = 0; i < response.payload.all.digest.garageDoor.length; i++) {
+        if(response.payload.all.digest.garageDoor[i].channel === this.config.channel) {
           isOpen = response.payload.all.digest.garageDoor[i].open;
         }
       }


### PR DESCRIPTION
I made some minor changes to support channels with the garage door opener, and have tested with the MSG100 and MSG200. I'm open to additional any additional changes, cleanup, or testing you'd like to see. This was just the minimal set of changes I needed to get it work.

The MSG100 uses channel 0, for the single door, but the MSG200 uses channels 1, 2, and 3. FWIW, setting channel 0 on the MSG200 to open or closed appears to control all doors.