### PR TITLE
Adds support for MSS630 device

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -85,6 +85,10 @@
             "enum": ["MSS620"]
           },
           {
+            "title": "MSS-630",
+            "enum": ["MSS630"]
+          },
+          {
             "title": "MSS-710",
             "enum": ["MSS710"]
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,7 @@ class Meross {
       case 'MSS425':
       case 'MSS425E':
       case 'MSS425F':
+      case 'MSS630':
       case 'MSS620':
         this.service = new Service.Outlet(this.config.name);
         break;


### PR DESCRIPTION
This is a simple change I made to support my MSS630, which is the 3 socket outdoor plug. Thought others might benefit from it as well. Works perfectly for me.

Sample config. 

 

>  {

            "model": "MSS630",
            "name": "Outlet 1",
            "firmwareRevision": "3.1.1",
            "deviceUrl": "10.0.0.139",
            "channel": 1,
            "messageId": "****",
            "timestamp": ****,
            "sign": "****",
            "accessory": "Meross"
        },
        {
            "model": "MSS630",
            "name": "Outlet 2",
            "firmwareRevision": "3.1.1",
            "deviceUrl": "10.0.0.139",
            "channel": 2,
            "messageId": "****",
            "timestamp": ****,
            "sign": "****",
            "accessory": "Meross"
        },
        {
            "model": "MSS630",
            "name": "Outlet 3",
            "firmwareRevision": "3.1.1",
            "deviceUrl": "10.0.0.139",
            "channel": 3,
            "messageId": "****",
            "timestamp": ****,
            "sign": "****",
            "accessory": "Meross"
        }