### PR TITLE
v4.0.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,5 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "editor.rulers": [ 140 ],
-  "eslint.enable": true
+  "editor.rulers": [ 140 ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
+## [Version 4.0.0](https://github.com/donavanbecker/homebridge-meross/compare/v3.5.0....4.0.0) (2021-3-02)
+
+### Major Changes
+
+- Homebridge support has moved to v1.3.1
+  - Homebridge v1.3.1 must be installed before updating to this version.
+  - Support for the new onGet/onSet introdcued in Homebridge v1.3.0.
+
+### Changes
+
+- Adding in MSL-320
+
 ## [Version 3.5.0](https://github.com/donavanbecker/homebridge-meross/compare/v3.4.1....3.5.0) (2021-2-13)
 
 ### Changes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,8 @@ currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.4.x   | :white_check_mark: |
-| < 3.3.0 | :x:                |
+| 4.x.x   | :white_check_mark: |
+| < 3.5.0 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -29,6 +29,10 @@
             "enum": ["MSL-120"]
           },
           {
+            "title": "MSL-320",
+            "enum": ["MSL-320"]
+          },
+          {
             "title": "MSL-420",
             "enum": ["MSL-420"]
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "homebridge-meross",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.5.0",
+      "version": "4.0.0",
       "funding": [
         {
           "type": "Paypal",
@@ -17,16 +17,13 @@
         "request": ">=2.88.2"
       },
       "devDependencies": {
-        "@types/minimal-request-promise": "^1.5.0",
-        "@types/node": "^14.14.27",
-        "@types/request-promise": "^4.1.47",
-        "@types/request-promise-native": "^1.0.17",
-        "@typescript-eslint/eslint-plugin": "^4.15.0",
-        "@typescript-eslint/parser": "^4.15.0",
-        "eslint": "^7.20.0",
+        "@types/node": "^14.14.31",
+        "@typescript-eslint/eslint-plugin": "^4.16.1",
+        "@typescript-eslint/parser": "^4.16.1",
+        "eslint": "^7.21.0",
         "eslint-plugin-prettier": "^3.3.1",
-        "homebridge": "^1.1.7",
-        "homebridge-config-ui-x": "^4.38.0",
+        "homebridge": "^1.3.1",
+        "homebridge-config-ui-x": "^4.39.1",
         "nodemon": "^2.0.7",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.2",
@@ -34,8 +31,8 @@
         "typescript": "^4.1.5"
       },
       "engines": {
-        "homebridge": ">=1.1.7",
-        "node": ">=14.15.1"
+        "homebridge": ">=1.3.1",
+        "node": ">=14.15.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -127,9 +124,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz",
-      "integrity": "sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==",
+      "version": "7.13.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.7.tgz",
+      "integrity": "sha512-zkDsGGSRU2YyYTXkPfcxuYuCVc6xBOeH1ZMh72ywBvmrDs+kSmoMuCUXZJUPbXZafrPivDHS2Oq7wI37gaTvqw==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.0.0",
@@ -137,9 +134,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -149,7 +146,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -162,6 +158,21 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
       "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
       "dev": true
+    },
+    "node_modules/@homebridge/ciao": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
+      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.19",
+        "tslib": "^2.0.3"
+      },
+      "bin": {
+        "ciao-bcs": "lib/bonjour-conformance-testing.js"
+      }
     },
     "node_modules/@nestjs/common": {
       "version": "7.6.5",
@@ -399,9 +410,9 @@
       }
     },
     "node_modules/@oznu/hap-client": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@oznu/hap-client/-/hap-client-1.7.0.tgz",
-      "integrity": "sha512-CFZnCfHmTLxG1cIcGCMs/aDuu1lr7mAcZH4keYnu0i7eG0qziEAFDCT1U3I0xF0ParZqnsO/QksJluwpL2E/ag==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@oznu/hap-client/-/hap-client-1.7.2.tgz",
+      "integrity": "sha512-nTq+ycTJ/tWLtJprzg/i/1ItChcfDgPy1CIw0HNGTWe2qgTDNzfzgatsXPN6K/8jQg/m1aib1pS0nraaIwdMhA==",
       "dev": true,
       "dependencies": {
         "axios": "0.21.1",
@@ -432,18 +443,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
-      "dev": true
-    },
-    "node_modules/@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -459,76 +458,16 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/minimal-request-promise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/minimal-request-promise/-/minimal-request-promise-1.5.0.tgz",
-      "integrity": "sha512-pVxgSK3zu6L8H8F82JntYG4bVo9PXPEPUgeXvn52SxZOFLJfvcESzhE1jjd7mJHKV3KB+ipoYhRi/j5u34/4Sw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
-      "version": "14.14.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.27.tgz",
-      "integrity": "sha512-Ecfmo4YDQPwuqTCl1yBxLV5ihKfRlkBmzUEDcfIRvDxOTGQEeikr317Ln7Gcv0tjA8dVgKI3rniqW2G1OyKDng==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
-    },
-    "node_modules/@types/request": {
-      "version": "2.48.5",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      }
-    },
-    "node_modules/@types/request-promise": {
-      "version": "4.1.47",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.47.tgz",
-      "integrity": "sha512-eRSZhAS8SMsrWOM8vbhxFGVZhTbWSJvaRKyufJTdIf4gscUouQvOBlfotPSPHbMR3S7kfkyKbhb1SWPmQdy3KQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/bluebird": "*",
-        "@types/request": "*"
-      }
-    },
-    "node_modules/@types/request-promise-native": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.17.tgz",
-      "integrity": "sha512-05/d0WbmuwjtGMYEdHIBZ0tqMJJQ2AD9LG2F6rKNBGX1SSFR27XveajH//2N/XYtual8T9Axwl+4v7oBtPUZqg==",
-      "dev": true,
-      "dependencies": {
-        "@types/request": "*"
-      }
-    },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
     },
     "node_modules/@types/swagger-schema-official": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.21.tgz",
       "integrity": "sha512-n9BbLOjR4Hre7B4TSGGMPohOgOg8tcp00uxqsIE00uuWQC0QuX57G1bqC1csLsk2DpTGtHkd0dEb3ipsCZ9dAA==",
-      "dev": true
-    },
-    "node_modules/@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "node_modules/@types/validator": {
@@ -538,13 +477,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
-      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz",
+      "integrity": "sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.15.0",
-        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/experimental-utils": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.16.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -570,15 +509,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
-      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz",
+      "integrity": "sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.15.0",
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/typescript-estree": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/typescript-estree": "4.16.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -594,14 +533,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
-      "integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.16.1.tgz",
+      "integrity": "sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.15.0",
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/typescript-estree": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/typescript-estree": "4.16.1",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -621,13 +560,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
-      "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz",
+      "integrity": "sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/visitor-keys": "4.15.0"
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/visitor-keys": "4.16.1"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -638,9 +577,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -651,13 +590,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
-      "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz",
+      "integrity": "sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/visitor-keys": "4.15.0",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/visitor-keys": "4.16.1",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -678,12 +617,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
-      "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz",
+      "integrity": "sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/types": "4.16.1",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1838,9 +1777,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
-      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
+      "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -1949,12 +1888,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
-      "dev": true
     },
     "node_modules/decompress-response": {
       "version": "4.2.1",
@@ -2490,13 +2423,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2509,7 +2442,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -2812,9 +2745,9 @@
       "dev": true
     },
     "node_modules/fast-srp-hap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.2.tgz",
-      "integrity": "sha512-wABhZRrFhlovqJQ1HygOUB4R6WZW2hmlpvVYh2dVCy8BPLabDrB/Tu6XI3B4QfmhtHk8s1OeiFqJHY7FBsphug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.3.tgz",
+      "integrity": "sha512-4P8TBD0all202L9FbeSsWc9qDlpaYp065VbUwbuNYZDYdOJ02UlWaDkai6d/+6/I8/sdtVYAVd17PEZDKbqopQ==",
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
@@ -2943,9 +2876,9 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
@@ -3395,22 +3328,31 @@
       "dev": true
     },
     "node_modules/hap-nodejs": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.7.10.tgz",
-      "integrity": "sha512-582WHUCRVKFtw1ITYvKsGrGw2Hhc/AINej0LuFhCYvzPqVf2/m+v5PdgEt4wqyJSTM9rG5uoVYp1t/hoDnlLsw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.2.tgz",
+      "integrity": "sha512-Dm+jM8Fb0R0esDJ508NqluY/9J1azcP5vp2Y9jAGKs72X0HasyMvkMgMQoa/pqd6Psf22J3ohQYZ8rlE0RNspw==",
       "dev": true,
       "dependencies": {
+        "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",
-        "debug": "^4.1.1",
-        "decimal.js": "^10.2.0",
-        "fast-srp-hap": "2.0.2",
+        "debug": "^4.3.1",
+        "fast-srp-hap": "2.0.3",
         "futoin-hkdf": "~1.3.2",
+        "ip": "^1.1.3",
         "node-persist": "^0.0.11",
+        "source-map-support": "^0.5.19",
+        "tslib": "^2.1.0",
         "tweetnacl": "^1.0.3"
       },
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/hap-nodejs/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+      "dev": true
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
@@ -3521,17 +3463,17 @@
       }
     },
     "node_modules/homebridge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.1.7.tgz",
-      "integrity": "sha512-A+cf5ZBatZu34wEVc1S5ztNtNjIbA31jwOMSZ6so8TeAQfcIYJRDHueHD7FgslMxkHol27nXt9vVMrugH4LtLA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.3.1.tgz",
+      "integrity": "sha512-JTADGF5E2nE2WXD4KUh8qEd4zCw7Pmy/0Htw8+qReDgD2/ARcDjCDl4G8QFlYe6UAbY5kt6RNzVBO/ktUcEckQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "commander": "5.1.0",
-        "hap-nodejs": "^0.7.10",
-        "node-persist": "^0.0.11",
+        "fs-extra": "^9.1.0",
+        "hap-nodejs": "0.9.2",
         "qrcode-terminal": "^0.12.0",
-        "semver": "^7.3.2",
+        "semver": "^7.3.4",
         "source-map-support": "^0.5.19"
       },
       "bin": {
@@ -3542,10 +3484,20 @@
       }
     },
     "node_modules/homebridge-config-ui-x": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-4.38.0.tgz",
-      "integrity": "sha512-3uUAwmpGf9HCQGn/jas8x25affGBeCAYS0p0QqpwNF0zta8XFJ/SJnwtGzLekFzRoqdr5nwoJuhWh5QIpj3Hvw==",
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-4.39.1.tgz",
+      "integrity": "sha512-UcImHnGyTZ3T54BHjewSubGjYhhR0pvJHJWgxrr5tVXMrITMhkrH/HLE3NsC4lh7T5O1le6BTj57ukN9mQ09wA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/oznu"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/oznu"
+        }
+      ],
       "dependencies": {
         "@nestjs/common": "7.6.5",
         "@nestjs/core": "7.6.5",
@@ -3555,7 +3507,7 @@
         "@nestjs/platform-socket.io": "7.6.5",
         "@nestjs/swagger": "4.7.12",
         "@nestjs/websockets": "7.6.5",
-        "@oznu/hap-client": "1.7.0",
+        "@oznu/hap-client": "1.7.2",
         "axios": "0.21.1",
         "class-transformer": "^0.3.2",
         "class-validator": "^0.13.1",
@@ -3568,9 +3520,10 @@
         "fs-extra": "9.1.0",
         "helmet": "4.4.1",
         "node-cache": "^5.1.2",
-        "node-pty-prebuilt-multiarch": "0.10.0",
+        "node-pty-prebuilt-multiarch": "0.10.1-pre.3",
         "node-schedule": "^1.3.2",
         "ora": "5.3.0",
+        "p-limit": "3.1.0",
         "passport": "0.4.1",
         "passport-jwt": "4.0.0",
         "pino-pretty": "^4.3.0",
@@ -4050,14 +4003,14 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
-      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       },
@@ -4776,9 +4729,9 @@
       }
     },
     "node_modules/node-pty-prebuilt-multiarch": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.0.tgz",
-      "integrity": "sha512-l1Oq8EjrAYXhA/XRb2V2+LZa2cRM5sjvzK8kXehPVszgEmpfgNHjNUddaWP9qOAVTvDiLCqrJC2tC2Zz0hUv/w==",
+      "version": "0.10.1-pre.3",
+      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.1-pre.3.tgz",
+      "integrity": "sha512-2IFS67xuhuVzIm46Ys2WLB3HG65EhxWECFfHkUbX2AFh3bXNsMdQiKAY1PTXf/nl45/EbMC2whc6BU8P99y7bg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4964,12 +4917,12 @@
       }
     },
     "node_modules/object-is": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "engines": {
@@ -5088,6 +5041,21 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json": {
@@ -5278,9 +5246,9 @@
       "dev": true
     },
     "node_modules/prebuild-install": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
       "dev": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -6298,12 +6266,12 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "funding": {
@@ -6311,12 +6279,12 @@
       }
     },
     "node_modules/string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       },
       "funding": {
@@ -7182,6 +7150,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -7264,9 +7244,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz",
-      "integrity": "sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==",
+      "version": "7.13.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.7.tgz",
+      "integrity": "sha512-zkDsGGSRU2YyYTXkPfcxuYuCVc6xBOeH1ZMh72ywBvmrDs+kSmoMuCUXZJUPbXZafrPivDHS2Oq7wI37gaTvqw==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -7274,9 +7254,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -7286,7 +7266,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       }
@@ -7296,6 +7275,18 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
       "integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
       "dev": true
+    },
+    "@homebridge/ciao": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.1.2.tgz",
+      "integrity": "sha512-31IfDKMqxfT+uVNXj0/TmYMou57gP8CUrh0vABzsc5QMsoCQ4Oo5uYQp0oJJyzxTBkF2pFvjR3XlWAapl0VyCg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "fast-deep-equal": "^3.1.3",
+        "source-map-support": "^0.5.19",
+        "tslib": "^2.0.3"
+      }
     },
     "@nestjs/common": {
       "version": "7.6.5",
@@ -7432,9 +7423,9 @@
       }
     },
     "@oznu/hap-client": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@oznu/hap-client/-/hap-client-1.7.0.tgz",
-      "integrity": "sha512-CFZnCfHmTLxG1cIcGCMs/aDuu1lr7mAcZH4keYnu0i7eG0qziEAFDCT1U3I0xF0ParZqnsO/QksJluwpL2E/ag==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@oznu/hap-client/-/hap-client-1.7.2.tgz",
+      "integrity": "sha512-nTq+ycTJ/tWLtJprzg/i/1ItChcfDgPy1CIw0HNGTWe2qgTDNzfzgatsXPN6K/8jQg/m1aib1pS0nraaIwdMhA==",
       "dev": true,
       "requires": {
         "axios": "0.21.1",
@@ -7459,18 +7450,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/bluebird": {
-      "version": "3.5.33",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
-      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
-      "dev": true
-    },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -7486,75 +7465,16 @@
         "@types/node": "*"
       }
     },
-    "@types/minimal-request-promise": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@types/minimal-request-promise/-/minimal-request-promise-1.5.0.tgz",
-      "integrity": "sha512-pVxgSK3zu6L8H8F82JntYG4bVo9PXPEPUgeXvn52SxZOFLJfvcESzhE1jjd7mJHKV3KB+ipoYhRi/j5u34/4Sw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
-      "version": "14.14.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.27.tgz",
-      "integrity": "sha512-Ecfmo4YDQPwuqTCl1yBxLV5ihKfRlkBmzUEDcfIRvDxOTGQEeikr317Ln7Gcv0tjA8dVgKI3rniqW2G1OyKDng==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
-    },
-    "@types/request": {
-      "version": "2.48.5",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
-      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
-      "dev": true,
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
-    "@types/request-promise": {
-      "version": "4.1.47",
-      "resolved": "https://registry.npmjs.org/@types/request-promise/-/request-promise-4.1.47.tgz",
-      "integrity": "sha512-eRSZhAS8SMsrWOM8vbhxFGVZhTbWSJvaRKyufJTdIf4gscUouQvOBlfotPSPHbMR3S7kfkyKbhb1SWPmQdy3KQ==",
-      "dev": true,
-      "requires": {
-        "@types/bluebird": "*",
-        "@types/request": "*"
-      }
-    },
-    "@types/request-promise-native": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.17.tgz",
-      "integrity": "sha512-05/d0WbmuwjtGMYEdHIBZ0tqMJJQ2AD9LG2F6rKNBGX1SSFR27XveajH//2N/XYtual8T9Axwl+4v7oBtPUZqg==",
-      "dev": true,
-      "requires": {
-        "@types/request": "*"
-      }
     },
     "@types/swagger-schema-official": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.21.tgz",
       "integrity": "sha512-n9BbLOjR4Hre7B4TSGGMPohOgOg8tcp00uxqsIE00uuWQC0QuX57G1bqC1csLsk2DpTGtHkd0dEb3ipsCZ9dAA==",
-      "dev": true
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/validator": {
@@ -7564,13 +7484,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
-      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.16.1.tgz",
+      "integrity": "sha512-SK777klBdlkUZpZLC1mPvyOWk9yAFCWmug13eAjVQ4/Q1LATE/NbcQL1xDHkptQkZOLnPmLUA1Y54m8dqYwnoQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.15.0",
-        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/experimental-utils": "4.16.1",
+        "@typescript-eslint/scope-manager": "4.16.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -7580,55 +7500,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
-      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.16.1.tgz",
+      "integrity": "sha512-0Hm3LSlMYFK17jO4iY3un1Ve9x1zLNn4EM50Lia+0EV99NdbK+cn0er7HC7IvBA23mBg3P+8dUkMXy4leL33UQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.15.0",
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/typescript-estree": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/typescript-estree": "4.16.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
-      "integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.16.1.tgz",
+      "integrity": "sha512-/c0LEZcDL5y8RyI1zLcmZMvJrsR6SM1uetskFkoh3dvqDKVXPsXI+wFB/CbVw7WkEyyTKobC1mUNp/5y6gRvXg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.15.0",
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/typescript-estree": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.16.1",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/typescript-estree": "4.16.1",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
-      "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.16.1.tgz",
+      "integrity": "sha512-6IlZv9JaurqV0jkEg923cV49aAn8V6+1H1DRfhRcvZUrptQ+UtSKHb5kwTayzOYTJJ/RsYZdcvhOEKiBLyc0Cw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/visitor-keys": "4.15.0"
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/visitor-keys": "4.16.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
-      "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
-      "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.16.1.tgz",
+      "integrity": "sha512-m8I/DKHa8YbeHt31T+UGd/l8Kwr0XCTCZL3H4HMvvLCT7HU9V7yYdinTOv1gf/zfqNeDcCgaFH2BMsS8x6NvJg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.15.0",
-        "@typescript-eslint/visitor-keys": "4.15.0",
+        "@typescript-eslint/types": "4.16.1",
+        "@typescript-eslint/visitor-keys": "4.16.1",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -7637,12 +7557,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
-      "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.16.1.tgz",
+      "integrity": "sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/types": "4.16.1",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -8569,9 +8489,9 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
-      "integrity": "sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
+      "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==",
       "dev": true
     },
     "core-util-is": {
@@ -8649,12 +8569,6 @@
       "requires": {
         "xregexp": "^4.2.4"
       }
-    },
-    "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
-      "dev": true
     },
     "decompress-response": {
       "version": "4.2.1",
@@ -9116,13 +9030,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+      "integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.3.0",
+        "@eslint/eslintrc": "^0.4.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -9135,7 +9049,7 @@
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^5.0.0",
         "globals": "^12.1.0",
@@ -9361,9 +9275,9 @@
       "dev": true
     },
     "fast-srp-hap": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.2.tgz",
-      "integrity": "sha512-wABhZRrFhlovqJQ1HygOUB4R6WZW2hmlpvVYh2dVCy8BPLabDrB/Tu6XI3B4QfmhtHk8s1OeiFqJHY7FBsphug==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fast-srp-hap/-/fast-srp-hap-2.0.3.tgz",
+      "integrity": "sha512-4P8TBD0all202L9FbeSsWc9qDlpaYp065VbUwbuNYZDYdOJ02UlWaDkai6d/+6/I8/sdtVYAVd17PEZDKbqopQ==",
       "dev": true
     },
     "fastify": {
@@ -9488,9 +9402,9 @@
       }
     },
     "file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
       "requires": {
         "flat-cache": "^3.0.4"
@@ -9839,18 +9753,29 @@
       "dev": true
     },
     "hap-nodejs": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.7.10.tgz",
-      "integrity": "sha512-582WHUCRVKFtw1ITYvKsGrGw2Hhc/AINej0LuFhCYvzPqVf2/m+v5PdgEt4wqyJSTM9rG5uoVYp1t/hoDnlLsw==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/hap-nodejs/-/hap-nodejs-0.9.2.tgz",
+      "integrity": "sha512-Dm+jM8Fb0R0esDJ508NqluY/9J1azcP5vp2Y9jAGKs72X0HasyMvkMgMQoa/pqd6Psf22J3ohQYZ8rlE0RNspw==",
       "dev": true,
       "requires": {
+        "@homebridge/ciao": "~1.1.2",
         "bonjour-hap": "~3.6.2",
-        "debug": "^4.1.1",
-        "decimal.js": "^10.2.0",
-        "fast-srp-hap": "2.0.2",
+        "debug": "^4.3.1",
+        "fast-srp-hap": "2.0.3",
         "futoin-hkdf": "~1.3.2",
+        "ip": "^1.1.3",
         "node-persist": "^0.0.11",
+        "source-map-support": "^0.5.19",
+        "tslib": "^2.1.0",
         "tweetnacl": "^1.0.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
       }
     },
     "har-schema": {
@@ -9936,24 +9861,24 @@
       "dev": true
     },
     "homebridge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.1.7.tgz",
-      "integrity": "sha512-A+cf5ZBatZu34wEVc1S5ztNtNjIbA31jwOMSZ6so8TeAQfcIYJRDHueHD7FgslMxkHol27nXt9vVMrugH4LtLA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/homebridge/-/homebridge-1.3.1.tgz",
+      "integrity": "sha512-JTADGF5E2nE2WXD4KUh8qEd4zCw7Pmy/0Htw8+qReDgD2/ARcDjCDl4G8QFlYe6UAbY5kt6RNzVBO/ktUcEckQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "commander": "5.1.0",
-        "hap-nodejs": "^0.7.10",
-        "node-persist": "^0.0.11",
+        "fs-extra": "^9.1.0",
+        "hap-nodejs": "0.9.2",
         "qrcode-terminal": "^0.12.0",
-        "semver": "^7.3.2",
+        "semver": "^7.3.4",
         "source-map-support": "^0.5.19"
       }
     },
     "homebridge-config-ui-x": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-4.38.0.tgz",
-      "integrity": "sha512-3uUAwmpGf9HCQGn/jas8x25affGBeCAYS0p0QqpwNF0zta8XFJ/SJnwtGzLekFzRoqdr5nwoJuhWh5QIpj3Hvw==",
+      "version": "4.39.1",
+      "resolved": "https://registry.npmjs.org/homebridge-config-ui-x/-/homebridge-config-ui-x-4.39.1.tgz",
+      "integrity": "sha512-UcImHnGyTZ3T54BHjewSubGjYhhR0pvJHJWgxrr5tVXMrITMhkrH/HLE3NsC4lh7T5O1le6BTj57ukN9mQ09wA==",
       "dev": true,
       "requires": {
         "@nestjs/common": "7.6.5",
@@ -9964,7 +9889,7 @@
         "@nestjs/platform-socket.io": "7.6.5",
         "@nestjs/swagger": "4.7.12",
         "@nestjs/websockets": "7.6.5",
-        "@oznu/hap-client": "1.7.0",
+        "@oznu/hap-client": "1.7.2",
         "axios": "0.21.1",
         "class-transformer": "^0.3.2",
         "class-validator": "^0.13.1",
@@ -9977,9 +9902,10 @@
         "fs-extra": "9.1.0",
         "helmet": "4.4.1",
         "node-cache": "^5.1.2",
-        "node-pty-prebuilt-multiarch": "0.10.0",
+        "node-pty-prebuilt-multiarch": "0.10.1-pre.3",
         "node-schedule": "^1.3.2",
         "ora": "5.3.0",
+        "p-limit": "3.1.0",
         "passport": "0.4.1",
         "passport-jwt": "4.0.0",
         "pino-pretty": "^4.3.0",
@@ -10300,14 +10226,14 @@
       }
     },
     "is-typed-array": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.4.tgz",
-      "integrity": "sha512-ILaRgn4zaSrVNXNGtON6iFNotXW3hAPF3+0fB1usg2jFlWqo5fEDdmJkz0zBfoi7Dgskr8Khi2xZ8cXqZEfXNA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+      "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.2",
-        "call-bind": "^1.0.0",
-        "es-abstract": "^1.18.0-next.1",
+        "call-bind": "^1.0.2",
+        "es-abstract": "^1.18.0-next.2",
         "foreach": "^2.0.5",
         "has-symbols": "^1.0.1"
       }
@@ -10899,9 +10825,9 @@
       }
     },
     "node-pty-prebuilt-multiarch": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.0.tgz",
-      "integrity": "sha512-l1Oq8EjrAYXhA/XRb2V2+LZa2cRM5sjvzK8kXehPVszgEmpfgNHjNUddaWP9qOAVTvDiLCqrJC2tC2Zz0hUv/w==",
+      "version": "0.10.1-pre.3",
+      "resolved": "https://registry.npmjs.org/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.10.1-pre.3.tgz",
+      "integrity": "sha512-2IFS67xuhuVzIm46Ys2WLB3HG65EhxWECFfHkUbX2AFh3bXNsMdQiKAY1PTXf/nl45/EbMC2whc6BU8P99y7bg==",
       "dev": true,
       "requires": {
         "nan": "^2.14.2",
@@ -11044,12 +10970,12 @@
       "dev": true
     },
     "object-is": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
-      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -11133,6 +11059,15 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
     },
     "package-json": {
       "version": "6.5.0",
@@ -11288,9 +11223,9 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
       "dev": true,
       "requires": {
         "detect-libc": "^1.0.3",
@@ -12104,22 +12039,22 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
-      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
-      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
+        "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
       }
     },
@@ -12797,6 +12732,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "displayName": "Homebridge Meross",
   "name": "homebridge-meross",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "description": "A Meross Plugin for Homebridge.",
   "license": "Apache-2.0",
-  "author": "donavanbecker/dylanfrankcom",
+  "author": "donavanbecker",
   "repository": {
     "type": "git",
     "url": "git://github.com/donavanbecker/homebridge-meross.git"
@@ -13,12 +13,11 @@
     "url": "https://github.com/donavanbecker/homebridge-meross/issues"
   },
   "engines": {
-    "node": ">=14.15.1",
-    "homebridge": ">=1.1.7"
+    "node": ">=14.15.4",
+    "homebridge": ">=1.3.1"
   },
   "main": "dist/index.js",
   "scripts": {
-    "audit": "npm audit fix",
     "update": "npm update",
     "lint": "eslint src/**.ts",
     "watch": "npm run build && npm link && nodemon",
@@ -44,16 +43,13 @@
     "request": ">=2.88.2"
   },
   "devDependencies": {
-    "@types/minimal-request-promise": "^1.5.0",
-    "@types/node": "^14.14.27",
-    "@types/request-promise": "^4.1.47",
-    "@types/request-promise-native": "^1.0.17",
-    "@typescript-eslint/eslint-plugin": "^4.15.0",
-    "@typescript-eslint/parser": "^4.15.0",
-    "eslint": "^7.20.0",
+    "@types/node": "^14.14.31",
+    "@typescript-eslint/eslint-plugin": "^4.16.1",
+    "@typescript-eslint/parser": "^4.16.1",
+    "eslint": "^7.21.0",
     "eslint-plugin-prettier": "^3.3.1",
-    "homebridge": "^1.1.7",
-    "homebridge-config-ui-x": "^4.38.0",
+    "homebridge": "^1.3.1",
+    "homebridge-config-ui-x": "^4.39.1",
     "nodemon": "^2.0.7",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,9 @@ class Meross {
       case 'MSL-120':
         this.service = new Service.Lightbulb(this.config.name);
         break;
+      case 'MSL-320':
+        this.service = new Service.Lightbulb(this.config.name);
+        break;
       case 'MSS210':
       case 'MSS310':
       case 'MSS420F':
@@ -306,6 +309,28 @@ class Meross {
           .on('set', this.setOnCharacteristicHandler.bind(this));
         break;
       case 'MSL-120':
+        this.service
+          .getCharacteristic(Characteristic.Hue)
+          .on('get', this.getHueCharacteristicHandler.bind(this))
+          .on('set', this.setHueCharacteristicHandler.bind(this));
+        this.service
+          .getCharacteristic(Characteristic.ColorTemperature)
+          .on('get', this.getColorTemperatureCharacteristicHandler.bind(this))
+          .on('set', this.setColorTemperatureCharacteristicHandler.bind(this));
+        this.service
+          .getCharacteristic(Characteristic.Saturation)
+          .on('get', this.getSaturationCharacteristicHandler.bind(this))
+          .on('set', this.setSaturationCharacteristicHandler.bind(this));
+        this.service
+          .getCharacteristic(Characteristic.Brightness)
+          .on('get', this.getBrightnessCharacteristicHandler.bind(this))
+          .on('set', this.setBrightnessCharacteristicHandler.bind(this));
+        this.service
+          .getCharacteristic(Characteristic.On)
+          .on('get', this.getOnCharacteristicHandler.bind(this))
+          .on('set', this.setOnCharacteristicHandler.bind(this));
+        break;
+      case 'MSL-320':
         this.service
           .getCharacteristic(Characteristic.Hue)
           .on('get', this.getHueCharacteristicHandler.bind(this))
@@ -460,6 +485,12 @@ class Meross {
      * it's called each time you open the Home app or when you open control center
      */
 
+    //RGB led lightstrips use a different endpoint for retrieving current on / off status
+    let namespace = 'Appliance.System.All';
+    if (this.config.model === 'MSL-320' ) {
+        namespace = 'Appliance.System.Online';
+    }
+
     //this.log(this.config, this.config.deviceUrl);
     let response;
 
@@ -483,7 +514,7 @@ class Meross {
             messageId: `${this.config.messageId}`,
             method: 'GET',
             from: `http://${this.config.deviceUrl}/config`,
-            namespace: 'Appliance.System.All',
+            namespace: namespace,
             timestamp: this.config.timestamp,
             sign: `${this.config.sign}`,
             payloadVersion: 1,
@@ -551,7 +582,7 @@ class Meross {
     );
 
     let payload;
-    if (this.config.model === 'MSL-100' || this.config.model === 'MSL-120' || this.config.model === 'MSL-420') {
+    if (this.config.model === 'MSL-100' || this.config.model === 'MSL-120' || this.config.model === 'MSL-320' || this.config.model === 'MSL-420') {
       payload = {
         light: {
           luminance: value,
@@ -627,6 +658,12 @@ class Meross {
      * it's called each time you open the Home app or when you open control center
      */
 
+    //RGB led lightstrips use a different endpoint for retrieving current on / off status
+    let namespace = 'Appliance.System.All';
+    if (this.config.model === 'MSL-320' ) {
+        namespace = 'Appliance.System.Online';
+    }
+    
     //this.log(this.config, this.config.deviceUrl);
     let response;
 
@@ -650,7 +687,7 @@ class Meross {
             messageId: `${this.config.messageId}`,
             method: 'GET',
             from: `http://${this.config.deviceUrl}/config`,
-            namespace: 'Appliance.System.All',
+            namespace: namespace,
             timestamp: this.config.timestamp,
             sign: `${this.config.sign}`,
             payloadVersion: 1,
@@ -769,6 +806,13 @@ class Meross {
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
+     
+	//RGB led lightstrips use a different endpoint for retrieving current on / off status
+    let namespace = 'Appliance.System.All';
+    if (this.config.model === 'MSL-320' ) {
+        namespace = 'Appliance.System.Online';
+    }
+     
     let response;
     /* Log to the console whenever this function is called */
     this.log.debug(
@@ -789,7 +833,7 @@ class Meross {
             messageId: `${this.config.messageId}`,
             method: 'GET',
             from: `http://${this.config.deviceUrl}/config`,
-            namespace: 'Appliance.System.All',
+            namespace: namespace,
             timestamp: this.config.timestamp,
             sign: `${this.config.sign}`,
             payloadVersion: 1,
@@ -855,6 +899,13 @@ class Meross {
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
+     
+    //RGB led lightstrips use a different endpoint for retrieving current on / off status
+    let namespace = 'Appliance.System.All';
+    if (this.config.model === 'MSL-320' ) {
+        namespace = 'Appliance.System.Online';
+    }   
+     
     //this.log(this.config, this.config.deviceUrl);
     let response;
     /* Log to the console whenever this function is called */
@@ -876,7 +927,7 @@ class Meross {
             messageId: `${this.config.messageId}`,
             method: 'GET',
             from: `http://${this.config.deviceUrl}/config`,
-            namespace: 'Appliance.System.All',
+            namespace: namespace,
             timestamp: this.config.timestamp,
             sign: `${this.config.sign}`,
             payloadVersion: 1,
@@ -995,6 +1046,13 @@ class Meross {
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
+     
+	//RGB led lightstrips use a different endpoint for retrieving current on / off status
+    let namespace = 'Appliance.System.All';
+    if (this.config.model === 'MSL-320' ) {
+        namespace = 'Appliance.System.Online';
+    }
+     
     //this.log(this.config, this.config.deviceUrl);
     let response;
     /* Log to the console whenever this function is called */
@@ -1016,7 +1074,7 @@ class Meross {
             messageId: `${this.config.messageId}`,
             method: 'GET',
             from: `http://${this.config.deviceUrl}/config`,
-            namespace: 'Appliance.System.All',
+            namespace: namespace,
             timestamp: this.config.timestamp,
             sign: `${this.config.sign}`,
             payloadVersion: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-const */
 /* eslint-disable no-useless-escape */
 'use strict';
-
+import { CharacteristicValue } from 'homebridge';
 import request from 'request';
 let Service, Characteristic;
 
@@ -276,104 +276,104 @@ class Meross {
       case 'MSG200':
         this.service
           .getCharacteristic(Characteristic.CurrentDoorState)
-          .on('get', this.getDoorStateHandler.bind(this));
+          .onGet(this.getDoorStateHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.TargetDoorState)
-          .on('get', this.getDoorStateHandler.bind(this))
-          .on('set', this.setDoorStateHandler.bind(this));
+          .onGet(this.getDoorStateHandler.bind(this))
+          .onSet(this.setDoorStateHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.ObstructionDetected)
-          .on('get', this.getObstructionDetectedHandler.bind(this));
+          .onGet(this.getObstructionDetectedHandler.bind(this));
         break;
       case 'MSL-100':
       case 'MSL-420':
         this.service
           .getCharacteristic(Characteristic.Hue)
-          .on('get', this.getHueCharacteristicHandler.bind(this))
-          .on('set', this.setHueCharacteristicHandler.bind(this));
+          .onGet(this.getHueCharacteristicHandler.bind(this))
+          .onSet(this.setHueCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.ColorTemperature)
-          .on('get', this.getColorTemperatureCharacteristicHandler.bind(this))
-          .on('set', this.setColorTemperatureCharacteristicHandler.bind(this));
+          .onGet(this.getColorTemperatureCharacteristicHandler.bind(this))
+          .onSet(this.setColorTemperatureCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Saturation)
-          .on('get', this.getSaturationCharacteristicHandler.bind(this))
-          .on('set', this.setSaturationCharacteristicHandler.bind(this));
+          .onGet(this.getSaturationCharacteristicHandler.bind(this))
+          .onSet(this.setSaturationCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Brightness)
-          .on('get', this.getBrightnessCharacteristicHandler.bind(this))
-          .on('set', this.setBrightnessCharacteristicHandler.bind(this));
+          .onGet(this.getBrightnessCharacteristicHandler.bind(this))
+          .onSet(this.setBrightnessCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.On)
-          .on('get', this.getOnCharacteristicHandler.bind(this))
-          .on('set', this.setOnCharacteristicHandler.bind(this));
+          .onGet(this.getOnCharacteristicHandler.bind(this))
+          .onSet(this.setOnCharacteristicHandler.bind(this));
         break;
       case 'MSL-120':
         this.service
           .getCharacteristic(Characteristic.Hue)
-          .on('get', this.getHueCharacteristicHandler.bind(this))
-          .on('set', this.setHueCharacteristicHandler.bind(this));
+          .onGet(this.getHueCharacteristicHandler.bind(this))
+          .onSet(this.setHueCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.ColorTemperature)
-          .on('get', this.getColorTemperatureCharacteristicHandler.bind(this))
-          .on('set', this.setColorTemperatureCharacteristicHandler.bind(this));
+          .onGet(this.getColorTemperatureCharacteristicHandler.bind(this))
+          .onSet(this.setColorTemperatureCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Saturation)
-          .on('get', this.getSaturationCharacteristicHandler.bind(this))
-          .on('set', this.setSaturationCharacteristicHandler.bind(this));
+          .onGet(this.getSaturationCharacteristicHandler.bind(this))
+          .onSet(this.setSaturationCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Brightness)
-          .on('get', this.getBrightnessCharacteristicHandler.bind(this))
-          .on('set', this.setBrightnessCharacteristicHandler.bind(this));
+          .onGet(this.getBrightnessCharacteristicHandler.bind(this))
+          .onSet(this.setBrightnessCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.On)
-          .on('get', this.getOnCharacteristicHandler.bind(this))
-          .on('set', this.setOnCharacteristicHandler.bind(this));
+          .onGet(this.getOnCharacteristicHandler.bind(this))
+          .onSet(this.setOnCharacteristicHandler.bind(this));
         break;
       case 'MSL-320':
         this.service
           .getCharacteristic(Characteristic.Hue)
-          .on('get', this.getHueCharacteristicHandler.bind(this))
-          .on('set', this.setHueCharacteristicHandler.bind(this));
+          .onGet(this.getHueCharacteristicHandler.bind(this))
+          .onSet(this.setHueCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.ColorTemperature)
-          .on('get', this.getColorTemperatureCharacteristicHandler.bind(this))
-          .on('set', this.setColorTemperatureCharacteristicHandler.bind(this));
+          .onGet(this.getColorTemperatureCharacteristicHandler.bind(this))
+          .onSet(this.setColorTemperatureCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Saturation)
-          .on('get', this.getSaturationCharacteristicHandler.bind(this))
-          .on('set', this.setSaturationCharacteristicHandler.bind(this));
+          .onGet(this.getSaturationCharacteristicHandler.bind(this))
+          .onSet(this.setSaturationCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.Brightness)
-          .on('get', this.getBrightnessCharacteristicHandler.bind(this))
-          .on('set', this.setBrightnessCharacteristicHandler.bind(this));
+          .onGet(this.getBrightnessCharacteristicHandler.bind(this))
+          .onSet(this.setBrightnessCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.On)
-          .on('get', this.getOnCharacteristicHandler.bind(this))
-          .on('set', this.setOnCharacteristicHandler.bind(this));
+          .onGet(this.getOnCharacteristicHandler.bind(this))
+          .onSet(this.setOnCharacteristicHandler.bind(this));
         break;
       case 'MSS560':
         this.service
           .getCharacteristic(Characteristic.Brightness)
-          .on('get', this.getBrightnessCharacteristicHandler.bind(this))
-          .on('set', this.setBrightnessCharacteristicHandler.bind(this));
+          .onGet(this.getBrightnessCharacteristicHandler.bind(this))
+          .onSet(this.setBrightnessCharacteristicHandler.bind(this));
         this.service
           .getCharacteristic(Characteristic.On)
-          .on('get', this.getOnCharacteristicHandler.bind(this))
-          .on('set', this.setOnCharacteristicHandler.bind(this));
+          .onGet(this.getOnCharacteristicHandler.bind(this))
+          .onSet(this.setOnCharacteristicHandler.bind(this));
         break;
       default:
         this.service
           .getCharacteristic(Characteristic.On)
-          .on('get', this.getOnCharacteristicHandler.bind(this))
-          .on('set', this.setOnCharacteristicHandler.bind(this));
+          .onGet(this.getOnCharacteristicHandler.bind(this))
+          .onSet(this.setOnCharacteristicHandler.bind(this));
     }
 
     /* Return both the main service (this.service) and the informationService */
     return [informationService, this.service];
   }
 
-  async setOnCharacteristicHandler(value, callback) {
+  public async setOnCharacteristicHandler(value: CharacteristicValue) {
     /* this is called when HomeKit wants to update the value of the characteristic as defined in our getServices() function */
     /* deviceUrl only requires ip address */
 
@@ -471,15 +471,9 @@ class Meross {
 
     /* Log to the console the value whenever this function is called */
     this.log.debug('setOnCharacteristicHandler:', value);
-
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     */
-    callback(null, this.isOn);
   }
 
-  async getOnCharacteristicHandler(callback) {
+  public async getOnCharacteristicHandler() {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
@@ -487,8 +481,8 @@ class Meross {
 
     //RGB led lightstrips use a different endpoint for retrieving current on / off status
     let namespace = 'Appliance.System.All';
-    if (this.config.model === 'MSL-320' ) {
-        namespace = 'Appliance.System.Online';
+    if (this.config.model === 'MSL-320') {
+      namespace = 'Appliance.System.Online';
     }
 
     //this.log(this.config, this.config.deviceUrl);
@@ -546,7 +540,7 @@ class Meross {
         break;
       default:
         if (response) {
-          if (response?.payload?.all?.digest?.togglex){
+          if (response?.payload?.all?.digest?.togglex) {
             let onOff = response.payload.all.digest.togglex[`${this.config.channel}`].onoff;
             this.log.debug('Retrieved status successfully: ', onOff);
             this.isOn = onOff;
@@ -559,17 +553,9 @@ class Meross {
 
     /* Log to the console the value whenever this function is called */
     this.log.debug('getOnCharacteristicHandler:', this.isOn);
-
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     * The second argument in the function should be the current value of the characteristic
-     * This is just an example so we will return the value from `this.isOn` which is where we stored the value in the set handler
-     */
-    callback(null, this.isOn);
   }
 
-  async setBrightnessCharacteristicHandler(value, callback) {
+  public async setBrightnessCharacteristicHandler(value: CharacteristicValue) {
     /* this is called when HomeKit wants to update the value of the characteristic as defined in our getServices() function */
     /* deviceUrl only requires ip address */
 
@@ -582,7 +568,10 @@ class Meross {
     );
 
     let payload;
-    if (this.config.model === 'MSL-100' || this.config.model === 'MSL-120' || this.config.model === 'MSL-320' || this.config.model === 'MSL-420') {
+    if (this.config.model === 'MSL-100' ||
+      this.config.model === 'MSL-120' ||
+      this.config.model === 'MSL-320' ||
+      this.config.model === 'MSL-420') {
       payload = {
         light: {
           luminance: value,
@@ -644,15 +633,9 @@ class Meross {
 
     /* Log to the console the value whenever this function is called */
     this.log.debug('setBrightnessCharacteristicHandler:', value);
-
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     */
-    callback(null, this.brightness);
   }
 
-  async getBrightnessCharacteristicHandler(callback) {
+  public async getBrightnessCharacteristicHandler() {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
@@ -660,10 +643,10 @@ class Meross {
 
     //RGB led lightstrips use a different endpoint for retrieving current on / off status
     let namespace = 'Appliance.System.All';
-    if (this.config.model === 'MSL-320' ) {
-        namespace = 'Appliance.System.Online';
+    if (this.config.model === 'MSL-320') {
+      namespace = 'Appliance.System.Online';
     }
-    
+
     //this.log(this.config, this.config.deviceUrl);
     let response;
 
@@ -718,22 +701,14 @@ class Meross {
 
     /* Log to the console the value whenever this function is called */
     this.log.debug('getBrightnessCharacteristicHandler:', this.brightness);
-
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     * The second argument in the function should be the current value of the characteristic
-     * This is just an example so we will return the value from `this.brightness` which is where we stored the value in the set handler
-     */
-    callback(null, this.brightness);
   }
 
-  async setColorTemperatureCharacteristicHandler(value, callback) {
+  public async setColorTemperatureCharacteristicHandler(value: CharacteristicValue) {
     let response;
     // Range on HomeKit is 140 - 500. 500 being yellow, 140 being white.
     // Range on Meross is 1-100. 1 being yellow, 100 being white.
     let mired = value;
-    let mr_temp = mired - 140;
+    let mr_temp = Number(mired) - 140;
     mr_temp = 360 - mr_temp;
     mr_temp = mr_temp / 360;
     mr_temp = Math.round(mr_temp * 100);
@@ -794,25 +769,20 @@ class Meross {
       'setColorTemperatureCharacteristicHandler:',
       this.temperature,
     );
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     */
-    callback(null, this.temperature);
   }
 
-  async getColorTemperatureCharacteristicHandler(callback) {
+  public async getColorTemperatureCharacteristicHandler() {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
-     
-	//RGB led lightstrips use a different endpoint for retrieving current on / off status
+
+    //RGB led lightstrips use a different endpoint for retrieving current on / off status
     let namespace = 'Appliance.System.All';
-    if (this.config.model === 'MSL-320' ) {
-        namespace = 'Appliance.System.Online';
+    if (this.config.model === 'MSL-320') {
+      namespace = 'Appliance.System.Online';
     }
-     
+
     let response;
     /* Log to the console whenever this function is called */
     this.log.debug(
@@ -869,17 +839,9 @@ class Meross {
       'getColorTemperatureCharacteristicHandler:',
       this.temperature,
     );
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     * The second argument in the function should be the current value of the characteristic
-     * This is just an example so we will return the value from `this.ColorTemperature`
-        * which is where we stored the value in the set handler
-     */
-    callback(null, this.temperature);
   }
 
-  async setHueCharacteristicHandler(value, callback) {
+  public setHueCharacteristicHandler(value: CharacteristicValue) {
     /* this is called when HomeKit wants to update the value of the characteristic as defined in our getServices() function */
     /* deviceUrl only requires ip address */
     //this.log(this.config, this.config.deviceUrl);
@@ -890,22 +852,20 @@ class Meross {
     );
     this.log.debug('Hue succeeded:', this.hue);
     this.log.debug('Sat succeeded:', this.saturation);
-
-    callback(null, this.hue);
   }
 
-  async getHueCharacteristicHandler(callback) {
+  public async getHueCharacteristicHandler() {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
-     
+
     //RGB led lightstrips use a different endpoint for retrieving current on / off status
     let namespace = 'Appliance.System.All';
-    if (this.config.model === 'MSL-320' ) {
-        namespace = 'Appliance.System.Online';
-    }   
-     
+    if (this.config.model === 'MSL-320') {
+      namespace = 'Appliance.System.Online';
+    }
+
     //this.log(this.config, this.config.deviceUrl);
     let response;
     /* Log to the console whenever this function is called */
@@ -963,16 +923,9 @@ class Meross {
     }
     /* Log to the console the value whenever this function is called */
     this.log.debug('gethueCharacteristicHandler:', this.hue);
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     * The second argument in the function should be the current value of the characteristic
-     * This is just an example so we will return the value from `this.hue` which is where we stored the value in the set handler
-     */
-    callback(null, this.hue);
   }
 
-  async setSaturationCharacteristicHandler(value, callback) {
+  public async setSaturationCharacteristicHandler(value: CharacteristicValue) {
     /* this is called when HomeKit wants to update the value of the characteristic as defined in our getServices() function */
     /* deviceUrl only requires ip address */
     //this.log(this.config, this.config.deviceUrl);
@@ -1034,25 +987,20 @@ class Meross {
     }
     /* Log to the console the value whenever this function is called */
     this.log.debug('setsaturationCharacteristicHandler:', value);
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     */
-    callback(null, this.saturation);
   }
 
-  async getSaturationCharacteristicHandler(callback) {
+  public async getSaturationCharacteristicHandler() {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
      */
-     
-	//RGB led lightstrips use a different endpoint for retrieving current on / off status
+
+    //RGB led lightstrips use a different endpoint for retrieving current on / off status
     let namespace = 'Appliance.System.All';
-    if (this.config.model === 'MSL-320' ) {
-        namespace = 'Appliance.System.Online';
+    if (this.config.model === 'MSL-320') {
+      namespace = 'Appliance.System.Online';
     }
-     
+
     //this.log(this.config, this.config.deviceUrl);
     let response;
     /* Log to the console whenever this function is called */
@@ -1116,16 +1064,9 @@ class Meross {
     }
     /* Log to the console the value whenever this function is called */
     this.log.debug('getsaturationCharacteristicHandler:', this.saturation);
-    /*
-     * The callback function should be called to return the value
-     * The first argument in the function should be null unless and error occured
-     * The second argument in the function should be the current value of the characteristic
-     * This is just an example so we will return the value from `this.hue` which is where we stored the value in the set handler
-     */
-    callback(null, this.saturation);
   }
 
-  async getDoorStateHandler(callback) {
+  public getDoorStateHandler(callback) {
     /*
      * this is called when HomeKit wants to retrieve the current state of the characteristic as defined in our getServices() function
      * it's called each time you open the Home app or when you open control center
@@ -1139,14 +1080,14 @@ class Meross {
       .catch((e) => this.log(`${e}`));
   }
 
-  async getObstructionDetectedHandler(callback) {
+  public getObstructionDetectedHandler(callback) {
     this.log.debug(
       `getObstructionDetectedHandler for ${this.config.model} at ${this.config.deviceUrl}...`,
     );
     callback(null, Characteristic.ObstructionDetected.NO);
   }
 
-  async setDoorStateHandler(value, callback) {
+  public setDoorStateHandler(value: CharacteristicValue) {
     /* this is called when HomeKit wants to update the value of the characteristic as defined in our getServices() function */
     /* deviceUrl only requires ip address */
 
@@ -1161,7 +1102,6 @@ class Meross {
             this.log('Target CLOSED, Current OPEN, close the door');
             this.currentState = Characteristic.CurrentDoorState.CLOSING;
             this.setDoorState(false);
-            callback();
             this.service.setCharacteristic(
               Characteristic.CurrentDoorState,
               Characteristic.CurrentDoorState.CLOSING,
@@ -1169,14 +1109,12 @@ class Meross {
           } else if (state === Characteristic.CurrentDoorState.CLOSED) {
             this.log('Target CLOSED, Current CLOSED, no change');
             this.currentState = Characteristic.CurrentDoorState.CLOSED;
-            callback();
           } else if (state === Characteristic.CurrentDoorState.OPENING) {
             this.log(
               'Target CLOSED, Current OPENING, stop the door (then it stays in open state)',
             );
             this.currentState = Characteristic.CurrentDoorState.OPEN;
             this.setDoorState(false);
-            callback();
             this.service.setCharacteristic(
               Characteristic.TargetDoorState,
               Characteristic.TargetDoorState.OPEN,
@@ -1188,30 +1126,25 @@ class Meross {
           } else if (state === Characteristic.CurrentDoorState.CLOSING) {
             this.log('Target CLOSED, Current CLOSING, no change');
             this.currentState = Characteristic.CurrentDoorState.CLOSING;
-            callback();
           } else if (state === Characteristic.CurrentDoorState.STOPPED) {
             this.log('Target CLOSED, Current STOPPED, close the door');
             this.currentState = Characteristic.CurrentDoorState.CLOSING;
             this.setDoorState(false);
-            callback();
             this.service.setCharacteristic(
               Characteristic.CurrentDoorState,
               Characteristic.CurrentDoorState.CLOSING,
             );
           } else {
             this.log('Target CLOSED, Current UNKOWN, no change');
-            callback();
           }
         } else if (value === Characteristic.TargetDoorState.OPEN) {
           if (state === Characteristic.CurrentDoorState.OPEN) {
             this.log('Target OPEN, Current OPEN, no change');
             this.currentState = Characteristic.CurrentDoorState.OPEN;
-            callback();
           } else if (state === Characteristic.CurrentDoorState.CLOSED) {
             this.log('Target OPEN, Current CLOSED, open the door');
             this.currentState = Characteristic.CurrentDoorState.OPENING;
             this.setDoorState(true);
-            callback();
             this.service.setCharacteristic(
               Characteristic.CurrentDoorState,
               Characteristic.CurrentDoorState.OPENING,
@@ -1219,14 +1152,12 @@ class Meross {
           } else if (state === Characteristic.CurrentDoorState.OPENING) {
             this.log('Target OPEN, Current OPENING, no change');
             this.currentState = Characteristic.CurrentDoorState.OPENING;
-            callback();
           } else if (state === Characteristic.CurrentDoorState.CLOSING) {
             this.log(
               'Target OPEN, Current CLOSING, Meross does not accept OPEN request while closing',
               ' since the sensor is already open, no change.',
             );
             this.currentState = Characteristic.CurrentDoorState.CLOSING;
-            callback();
             this.service.setCharacteristic(
               Characteristic.TargetDoorState,
               Characteristic.TargetDoorState.CLOSING,
@@ -1239,14 +1170,12 @@ class Meross {
             this.log('Target OPEN, Current STOPPED, open the door');
             this.currentState = Characteristic.CurrentDoorState.OPENING;
             this.setDoorState(true);
-            callback();
             this.service.setCharacteristic(
               Characteristic.CurrentDoorState,
               Characteristic.CurrentDoorState.OPENING,
             );
           } else {
             this.log('Target OPEN, Current UNKOWN, no change');
-            callback();
           }
         }
       })
@@ -1329,8 +1258,8 @@ class Meross {
     if (response?.payload?.all?.digest?.garageDoor) {
       // Open means magnetic sensor not detected, doesn't really mean the door is open
       let isOpen = (this.currentState === Characteristic.CurrentDoorState.OPEN);
-      for(let i = 0; i < response.payload.all.digest.garageDoor.length; i++) {
-        if(response.payload.all.digest.garageDoor[i].channel === this.config.channel) {
+      for (let i = 0; i < response.payload.all.digest.garageDoor.length; i++) {
+        if (response.payload.all.digest.garageDoor[i].channel === this.config.channel) {
           isOpen = response.payload.all.digest.garageDoor[i].open;
         }
       }


### PR DESCRIPTION
## [Version 4.0.0](https://github.com/donavanbecker/homebridge-meross/compare/v3.5.0....4.0.0) (2021-3-02)

### Major Changes

- Homebridge support has moved to v1.3.1
  - Homebridge v1.3.1 must be installed before updating to this version.
  - Support for the new onGet/onSet introdcued in Homebridge v1.3.0.

### Changes

- Adding in MSL-320