### PR TITLE
Fixed a bug that does not properly retrieve the status of an outlet device.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -543,7 +543,7 @@ class Meross {
           if (response?.payload?.all?.digest?.togglex) {
             let onOff = response.payload.all.digest.togglex[`${this.config.channel}`].onoff;
             this.log.debug('Retrieved status successfully: ', onOff);
-            this.isOn = onOff;
+            this.isOn = onOff? true : false; // the received value was 1, not a boolean typed value.
           }
         } else {
           this.log.debug('Retrieved status unsuccessfully.');
@@ -553,6 +553,7 @@ class Meross {
 
     /* Log to the console the value whenever this function is called */
     this.log.debug('getOnCharacteristicHandler:', this.isOn);
+    return this.isOn;
   }
 
   public async setBrightnessCharacteristicHandler(value: CharacteristicValue) {


### PR DESCRIPTION
I've found a bug that the homebridge-meross does not retrieve the status of an outlet device.
Here is the log message:
```
[3/12/2021, 10:53:16 AM] [dev1] calling getOnCharacteristicHandler for MSS310 at 192.168.1.27...
[3/12/2021, 10:53:16 AM] [dev1] Retrieved status successfully:  1
[3/12/2021, 10:53:16 AM] [dev1] getOnCharacteristicHandler: 1
[3/12/2021, 10:53:16 AM] [homebridge-meross] This plugin generated a warning from the characteristic 'On': characteristic value expected boolean and received undefined. See https://git.io/JtMGR for more info.
[3/12/2021, 10:53:16 AM] [homebridge-meross] Error:
    at On.Characteristic.characteristicWarning (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:2032:105)
    at On.Characteristic.validateUserInput (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1909:14)
    at On.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/src/lib/Characteristic.ts:1454:24)
    at step (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:143:27)
    at Object.next (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:124:57)
    at fulfilled (/usr/local/lib/node_modules/homebridge/node_modules/tslib/tslib.js:114:62)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

Please check the bugfix.
Thank you.
