### PR TITLE
Removed a double quote in property for garage door 

### DIFF
--- a/src/devices/garagedoors.ts
+++ b/src/devices/garagedoors.ts
@@ -218,7 +218,7 @@ export class GarageDoor {
         messageId: `${this.device.messageId}`,
         method: 'SET',
         from: `http://${this.device.deviceUrl}/config`,
-        namespace: 'Appliance.GarageDoor.State"',
+        namespace: 'Appliance.GarageDoor.State',
         timestamp: this.device.timestamp,
         sign: `${this.device.sign}`,
         payloadVersion: 1,


### PR DESCRIPTION
There was a wrong double quote within the namespace property of the "data info" object for the "SET" request, which caused a "socket hung up" error