### PR TITLE
Fixes issue where MSL-120 payload fails to be read

### DIFF
--- a/src/devices/lightbulbs.ts
+++ b/src/devices/lightbulbs.ts
@@ -106,6 +106,14 @@ export class lightBulb {
       });
   }
 
+  calculateTemperature(payload_temperature: number) {
+    let mr_temp = (payload_temperature / 100) * 360;
+    mr_temp = 360 - mr_temp;
+    mr_temp = mr_temp + 140;
+    mr_temp = Math.round(mr_temp);
+    return mr_temp;
+  }
+
   parseStatus() {
     switch (this.device.model) {
       case 'MSS110-1':
@@ -138,12 +146,8 @@ export class lightBulb {
             this.Brightness = this.On ? 100 : 0;
           }
           if (this.deviceStatus?.payload?.all?.digest?.light?.temperature) {
-            const tmp_temperature = this.deviceStatus.payload.all.digest.light.temperature;
-            let mr_temp = (tmp_temperature / 100) * 360;
-            mr_temp = 360 - mr_temp;
-            mr_temp = mr_temp + 140;
-            mr_temp = Math.round(mr_temp);
-            this.ColorTemperature = mr_temp;
+            const payload_temperature = this.deviceStatus.payload.all.digest.light.temperature;
+            this.ColorTemperature = this.calculateTemperature(payload_temperature);
             this.platform.log.debug(
               'Retrieved temp status successfully: ',
               this.ColorTemperature,
@@ -152,7 +156,7 @@ export class lightBulb {
           if (this.deviceStatus?.payload?.all?.digest?.light) {
             this.platform.log.debug(
               'Retrieved status successfully: ',
-              this.deviceStatus.response.payload.all.digest.light,
+              this.deviceStatus.payload.all.digest.light,
             );
 
             const light_rgb = this.deviceStatus.payload.all.digest.light.rgb;
@@ -166,7 +170,7 @@ export class lightBulb {
           }
           if (this.deviceStatus?.payload?.all?.digest?.light) {
             this.Brightness = this.deviceStatus.payload.all.digest.light.luminance;
-            this.ColorTemperature = this.deviceStatus.payload.all.digest.light.temperature;
+            this.ColorTemperature = this.calculateTemperature(this.deviceStatus.payload.all.digest.light.temperature);
 
             const light_rgb = this.deviceStatus.payload.all.digest.light.rgb;
             const rgb = numberToColour(light_rgb);
@@ -198,7 +202,7 @@ export class lightBulb {
         break;
       case 'MSL-120':
         this.Namespace = 'Appliance.System.All';
-        this.Method = 'GETACK';
+        this.Method = 'GET';
         break;
       default:
         this.Namespace = 'Appliance.System.All';


### PR DESCRIPTION
3 main items went into this fix.

1. The MSL-120 uses a `GET` when fetching the status of the bulb.
2. The `Cannot read property 'payload' of undefined` bug was caused by an extra prop being added into the "Retrieved status successfully:" debug log entry.
3. Once the above 2 items were resolved there popped up a ColorTemperature characteristic warning. I found this to be due to one of the instances of setting `this.ColorTemperature` wasn't using the calculations to adjust the Meross' bulb temperature value to a value that HomeKit was expecting of at least 140. In that fix I thought it best to move the calculating of the temperature out to a helper method so it could be more easily implemented / updated whenever changes might be needed in the future.

Fixes #250 
