### PR TITLE
Fix MTS215/MTS215B humidity request and add SummerMode support

### DIFF
--- a/lib/device/thermostat-mts215.js
+++ b/lib/device/thermostat-mts215.js
@@ -43,19 +43,32 @@ export default class {
       4: this.cusChar.ValveEconomyMode,
     }
 
+    // Appliance.Control.Thermostat.SummerMode (mode: 1 = heat orientation, 2 = cool
+    // orientation) tells us whether the device is wired to heating or cooling
+    // equipment -- it flips which direction "state: 1" (actively calling) means,
+    // and which HomeKit HeatingCoolingState value should represent it. Comes
+    // bundled in the same Appliance.System.All digest as mode/windowOpened, so no
+    // extra request is needed; corrected as soon as the first poll comes back.
+    //
+    // Read-only here on purpose: this reflects how the installation is physically
+    // wired (boiler vs AC), not something to flip live from HomeKit like a sensor
+    // or a mode setting. If that's ever wanted, it can be set with
+    //   sendUpdate(accessory, { namespace: 'Appliance.Control.Thermostat.SummerMode',
+    //     payload: { summerMode: [{ channel: 0, mode: 1|2 }] } })
+    // -- note the SETACK payload comes back empty even on success, so the write
+    // has to be confirmed with a follow-up GET rather than trusted from the SET
+    // response (confirmed empirically, same device).
+    this.cacheSummerMode = false
+
     // Add the thermostat service if it doesn't already exist
     this.service = this.accessory.getService(this.hapServ.Thermostat)
       || this.accessory.addService(this.hapServ.Thermostat)
 
     this.service
       .getCharacteristic(this.hapChar.TargetHeatingCoolingState)
-      .setProps({
-        minValue: 0,
-        maxValue: 1,
-        validValues: [0, 1],
-      })
       .onSet(async value => this.internalStateUpdate(value))
     this.cacheState = this.service.getCharacteristic(this.hapChar.TargetHeatingCoolingState).value
+    this.updateHeatCoolProps()
 
     this.service
       .getCharacteristic(this.hapChar.TargetTemperature)
@@ -282,10 +295,13 @@ export default class {
         this.cacheTarg = value
         this.accessory.log(`${platformLang.curTarg} [${value}°C]`)
 
-        // Update the current heating state
+        // Update the current heating state (optimistic -- confirmed by the next poll).
+        // Direction depends on SummerMode: heating calls when the target is above the
+        // current temperature, cooling calls when it's below.
+        const isCalling = this.cacheSummerMode ? value < this.cacheTemp : value > this.cacheTemp
         this.service.updateCharacteristic(
           this.hapChar.CurrentHeatingCoolingState,
-          value > this.cacheTemp ? 1 : 0,
+          isCalling ? this.heatCoolValue() : this.hapChar.CurrentHeatingCoolingState.OFF,
         )
 
         // Turn the modes off as back to manual mode
@@ -321,6 +337,30 @@ export default class {
     } catch (err) {
       this.accessory.logWarn(`${platformLang.storageWriteErr} ${parseError(err)}`)
     }
+  }
+
+  // Returns which HomeKit HeatingCoolingState value ("calling") means on this
+  // device right now: Cool if Appliance.Control.Thermostat.SummerMode says this is
+  // wired to cooling equipment, Heat otherwise.
+  heatCoolValue() {
+    return this.cacheSummerMode ? this.hapChar.CurrentHeatingCoolingState.COOL : this.hapChar.CurrentHeatingCoolingState.HEAT
+  }
+
+  // Restricts TargetHeatingCoolingState to Off + whichever of Heat/Cool actually
+  // applies given the current SummerMode -- offering the other one in HomeKit would
+  // let the user pick a state the device can't actually honour (SummerMode is
+  // read-only here, see the constructor for why).
+  updateHeatCoolProps() {
+    const validValues = this.cacheSummerMode
+      ? [this.hapChar.TargetHeatingCoolingState.OFF, this.hapChar.TargetHeatingCoolingState.COOL]
+      : [this.hapChar.TargetHeatingCoolingState.OFF, this.hapChar.TargetHeatingCoolingState.HEAT]
+    this.service
+      .getCharacteristic(this.hapChar.TargetHeatingCoolingState)
+      .setProps({
+        minValue: 0,
+        maxValue: Math.max(...validValues),
+        validValues,
+      })
   }
 
   // Creates or removes a ContactSensor based on whether the corresponding protection
@@ -495,6 +535,18 @@ export default class {
 
   applyUpdate(data) {
     try {
+      // Read SummerMode before mode/state so the heat-vs-cool direction used below
+      // is already up to date if both arrived in the same digest (the normal case).
+      const summerModeData = data.summerMode?.[0]
+      if (summerModeData && hasProperty(summerModeData, 'mode')) {
+        const newSummerMode = summerModeData.mode === 2
+        if (this.cacheSummerMode !== newSummerMode) {
+          this.cacheSummerMode = newSummerMode
+          this.updateHeatCoolProps()
+          this.accessory.log(`${platformLang.curSummerMode} [${newSummerMode ? 'cool' : 'heat'}]`)
+        }
+      }
+
       const modeData = data.mode?.[0]
       if (modeData) {
         let needsUpdate = false
@@ -503,7 +555,10 @@ export default class {
 
           // Check against the cache and update HomeKit and the cache if needed
           if (this.cacheState !== newState) {
-            this.service.updateCharacteristic(this.hapChar.TargetHeatingCoolingState, newState)
+            this.service.updateCharacteristic(
+              this.hapChar.TargetHeatingCoolingState,
+              newState === 1 ? this.heatCoolValue() : this.hapChar.TargetHeatingCoolingState.OFF,
+            )
             this.cacheState = newState
             this.accessory.log(`${platformLang.curState} [${newState === 1 ? 'on' : 'off'}]`)
             needsUpdate = true
@@ -536,11 +591,15 @@ export default class {
           }
         }
 
-        // Update the current heating state
+        // Update the current heating state. Direction depends on SummerMode: heating
+        // calls when the target is above the current temperature, cooling calls when
+        // it's below -- but this.cacheState (from the device's own "state" field)
+        // already reflects whether it's actually calling either way, so it's trusted
+        // directly rather than re-derived from the temperatures here.
         if (needsUpdate) {
           this.service.updateCharacteristic(
             this.hapChar.CurrentHeatingCoolingState,
-            this.cacheState === 1 && this.cacheTarg > this.cacheTemp ? 1 : 0,
+            this.cacheState === 1 ? this.heatCoolValue() : this.hapChar.CurrentHeatingCoolingState.OFF,
           )
         }
       }

--- a/lib/device/thermostat-mts215.js
+++ b/lib/device/thermostat-mts215.js
@@ -426,6 +426,11 @@ export default class {
         try {
           const humRes = await this.platform.sendUpdate(this.accessory, {
             namespace: 'Appliance.Control.Sensor.Latest',
+            // Explicit GET: sendUpdate() defaults to SET whenever the payload
+            // isn't empty, but this payload only selects the channel to read --
+            // the device accepts GET for this namespace and closes the
+            // connection outright if sent SET (confirmed empirically).
+            method: 'GET',
             payload: { latest: [{ channel: 0 }] },
           })
           this.applyUpdate(humRes.data.payload)

--- a/lib/utils/lang-en.js
+++ b/lib/utils/lang-en.js
@@ -44,6 +44,7 @@ export default {
   curSpeed: 'current speed',
   curSpray: 'current spray',
   curState: 'current state',
+  curSummerMode: 'current summer mode',
   curTarg: 'current target',
   curTemp: 'current temperature',
   curVol: 'current volume',


### PR DESCRIPTION
### Summary

Since #798 was merged, humidity on MTS215/MTS215B never updates past its first cached value. `sendUpdate()` defaults an unspecified `method` to `SET` whenever the payload isn't empty:

```js
toSend.method = toSend.method || (Object.keys(toSend.payload).length === 0 ? 'GET' : 'SET')
```

The humidity request's payload only selects a channel (`{ latest: [{ channel: 0 }] }`) — it isn't setting anything — but being non-empty it falls into that default and gets sent as `SET`. On a real MTS215B, `Appliance.Control.Sensor.Latest` accepts `GET` but closes the connection outright when sent `SET`, rather than returning a clean error. Local control fails immediately, the plugin falls back to cloud, and that fails too after the 9s timeout — so the request never succeeds, and Homebridge just keeps showing whatever humidity value it last had cached.

### Fix

One line: pass `method: 'GET'` explicitly on the humidity request in `thermostat-mts215.js`.

### Also added: SummerMode support

While tracing through this, checking whether Frost/Overheat had the same `SET` issue (they don't — see the discussion below) led to noticing that `Appliance.Control.Thermostat.SummerMode` wasn't accounted for anywhere. This device can be wired to either heating or cooling equipment, and `SummerMode` (`mode: 1` = heat, `2` = cool) tells the firmware which — it flips what `state: 1` ("actively calling") actually means, confirmed empirically including via the official app's own cooling-temperature picker when `SummerMode` is on.

Without this, the plugin always reported "Heat" regardless of which way the device was actually wired/oriented, and offered a nonsensical "Heat" option in HomeKit even when the device was in cooling orientation.

- `TargetHeatingCoolingState` now offers Off + whichever of Heat/Cool actually applies, instead of being hardcoded to Off/Heat only.
- Both `TargetHeatingCoolingState` and `CurrentHeatingCoolingState` report Cool instead of Heat when the device is in cooling orientation.
- `SummerMode` comes bundled in the same `Appliance.System.All` digest already being polled, so no extra request is needed.
- Read-only for now — `SummerMode` reflects how the installation is physically wired, not something to toggle live from HomeKit. The constructor has a comment on how to add write support later if that's ever wanted.

### Testing

I'd like to hold off merging for a few more days to run this against my own installation through a real heat/cool orientation cycle before calling it done, rather than merging on API-level testing alone. Will comment here once I'm confident in it.
